### PR TITLE
publish to npm?

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "cutjs",
   "version": "0.1.49",
   "description": "Lightweight, fast, interactable 2D HTML5 rendering engine for cross-platform game development.",
+  "main": "./dist/cut.web.js",
   "homepage": "http://cutjs.org/",
   "keywords": [
     "html5",
@@ -15,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/piqnt/cutjs/"
+    "url": "https://github.com/piqnt/cutjs.git"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Hey -- cool library!

I'd love to be able to `npm install` this and require it node-style with a tool like [browserify](http://browserify.org/)

Are you up for doing an `npm publish`?  With my PR you should be good to go.

Npm [recommends](https://www.npmjs.org/doc/json.html#name) not using 'js' in the package name (I don't totally agree with this but whatever). However, there is an unrelated package [cut](https://www.npmjs.org/package/cut) on npm already -- maybe you could use "cut-engine" or "cut-renderer"?

Or you could just publish it under "cutjs" and screw the convention.

Note though that this only includes cut-web, I didn't really know what do with cut-fc and cut-cordova. If those need to be integrated I would still encourage publishing now so that people (like me) could start playing around with it in the npm/browserify way.
